### PR TITLE
Fix issue preventing conditions widget from rendering in Django 2.1+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Lucas Connors <lucas@revolutiontech.ca>
+Copyright (c) 2020, Lucas Connors <lucas@revolutiontech.ca>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/conditions/fields.py
+++ b/conditions/fields.py
@@ -32,7 +32,7 @@ class ConditionsWidget(JSONWidget):
             kwargs['attrs']['cols'] = 50
         super(ConditionsWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if isinstance(value, CondList):
             value = value.encode()
         textarea = super(ConditionsWidget, self).render(name, value, attrs)

--- a/conditions/tests/admin.py
+++ b/conditions/tests/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from .models import Campaign
+
+admin.site.register(Campaign)

--- a/conditions/tests/tests.py
+++ b/conditions/tests/tests.py
@@ -9,49 +9,50 @@ from .models import UserProfile, Campaign
 
 class CampaignTest(TestCase):
 
-    def setUp(self):
-        self.mrx = User.objects.create_user(
+    @classmethod
+    def setUpTestData(cls):
+        cls.mrx = User.objects.create_user(
             username='mr.x',
             email='x@gmail.com',
             password='top_secret'
         )
-        self.mrsy = User.objects.create_user(
+        cls.mrsy = User.objects.create_user(
             username='mrs.y',
             email='y@yahoo.com',
             password='also_top_secret'
         )
         # Create UserProfile objects
-        for user in [self.mrx, self.mrsy]:
+        for user in [cls.mrx, cls.mrsy]:
             UserProfile.objects.create(user=user)
 
         # Set Mr. X to have been a long-term member
-        self.mrx.date_joined = datetime.datetime(day=31, month=12, year=2013)
+        cls.mrx.date_joined = datetime.datetime(day=31, month=12, year=2013)
 
-        self.campaign = Campaign.objects.create(
+        cls.campaign = Campaign.objects.create(
             text="Thanks for providing your full name.",
             conditions={
                 'all': ["FULL_NAME"],
             }
         )
-        self.comparecondition_campaign = Campaign.objects.create(
+        cls.comparecondition_campaign = Campaign.objects.create(
             text="Congratulations on getting to Level 5!",
             conditions={
                 'all': ["LEVEL == 5"],
             }
         )
-        self.long_term_user_campaign = Campaign.objects.create(
+        cls.long_term_user_campaign = Campaign.objects.create(
             text="Thanks for being a long-term member.",
             conditions={
                 'any': ["DATE_JOINED < 01/01/2014"],
             }
         )
-        self.non_gmail_users_campaign = Campaign.objects.create(
+        cls.non_gmail_users_campaign = Campaign.objects.create(
             text="Why aren\'t you using Gmail?",
             conditions={
                 'all': ["NOT EMAIL_DOMAIN gmail.com"]
             }
         )
-        self.long_term_gmail_yahoo_user_campaign = Campaign.objects.create(
+        cls.long_term_gmail_yahoo_user_campaign = Campaign.objects.create(
             text="You\'ve been using the same email for a long time.",
             conditions={
                 'all': [

--- a/conditions/tests/tests.py
+++ b/conditions/tests/tests.py
@@ -1,4 +1,5 @@
 import datetime
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -7,7 +8,7 @@ from ..lists import eval_conditions
 from .models import UserProfile, Campaign
 
 
-class CampaignTest(TestCase):
+class DjangoConditionsTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -64,6 +65,9 @@ class CampaignTest(TestCase):
             }
         )
 
+
+class TestEvalConditions(DjangoConditionsTestCase):
+
     def test_basic_campaign_targetting(self):
         # Neither user should be targetted before having a name
         self.assertFalse(eval_conditions(self.campaign, 'conditions', self.mrx))
@@ -112,3 +116,17 @@ class CampaignTest(TestCase):
         # Even though they both use either Gmail or Yahoo!, only Mr. X is targeted
         self.assertTrue(eval_conditions(self.long_term_gmail_yahoo_user_campaign, 'conditions', self.mrx))
         self.assertFalse(eval_conditions(self.long_term_gmail_yahoo_user_campaign, 'conditions', self.mrsy))
+
+
+class TestAdmin(DjangoConditionsTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser("admin")
+
+    def setUp(self):
+        self.client.force_login(self.admin_user)
+
+    def test_render(self):
+        response = self.client.get("/admin/tests/campaign/add/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/conditions/tests/urls.py
+++ b/conditions/tests/urls.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls)
+]

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,6 +1,17 @@
 Installation
 ^^^^^^^^^^^^
 
+First install the ``django-conditions`` package:
+
 .. code-block:: bash
 
     pip install django-conditions
+
+Then add ``conditions`` to your ``INSTALLED_APPS`` setting:
+
+.. code-block:: python
+
+    INSTALLED_APPS = [
+        ...
+        'conditions',
+    ]

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,32 @@ class TestCommand(Command):
                 }
             },
             INSTALLED_APPS=(
+                'django.contrib.admin',
                 'django.contrib.auth',
                 'django.contrib.contenttypes',
+                'django.contrib.messages',
+                'django.contrib.sessions',
                 'conditions',
                 'conditions.tests',
-            )
+            ),
+            TEMPLATES=[
+                {
+                    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                    'APP_DIRS': True,
+                    'OPTIONS': {
+                        'context_processors': [
+                            'django.contrib.auth.context_processors.auth',
+                            'django.contrib.messages.context_processors.messages',
+                        ]
+                    },
+                }
+            ],
+            MIDDLEWARE=[
+                'django.contrib.sessions.middleware.SessionMiddleware',
+                'django.contrib.auth.middleware.AuthenticationMiddleware',
+                'django.contrib.messages.middleware.MessageMiddleware',
+            ],
+            ROOT_URLCONF='conditions.tests.urls'
         )
         django.setup()
         call_command('migrate')


### PR DESCRIPTION
When trying to render the conditions widget in the Django admin on Django versions 2.1+, the page fails with the following exception:
```
TypeError: render() got an unexpected keyword argument 'renderer'
```

The `renderer` argument is required as of Django 2.1:
https://docs.djangoproject.com/en/dev/releases/2.1/#features-removed-in-2-1

This PR fixes the issue by adding the `renderer` argument, and also adds a basic test to validate that the widget can render.